### PR TITLE
feat: replace contact form with social links

### DIFF
--- a/src/app/page2/page.js
+++ b/src/app/page2/page.js
@@ -178,53 +178,30 @@ export default function Home() {
         {/* Contacto */}
         <section id="contacto" className="container mx-auto px-6 py-16 max-w-3xl">
           <h3 className="text-3xl font-bold text-indigo-700 mb-8 text-center">Contáctanos</h3>
-          <form className="space-y-6 bg-white rounded-xl shadow-md p-8">
-            <div>
-              <label htmlFor="nombre" className="block text-sm font-medium text-gray-700">
-                Nombre
-              </label>
-              <input
-                id="nombre"
-                name="nombre"
-                type="text"
-                required
-                className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:ring-indigo-500 focus:border-indigo-500"
-                placeholder="Tu nombre"
-              />
-            </div>
-            <div>
-              <label htmlFor="email" className="block text-sm font-medium text-gray-700">
-                Email
-              </label>
-              <input
-                id="email"
-                name="email"
-                type="email"
-                required
-                className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:ring-indigo-500 focus:border-indigo-500"
-                placeholder="tu@email.com"
-              />
-            </div>
-            <div>
-              <label htmlFor="mensaje" className="block text-sm font-medium text-gray-700">
-                Mensaje
-              </label>
-              <textarea
-                id="mensaje"
-                name="mensaje"
-                rows={4}
-                required
-                className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:ring-indigo-500 focus:border-indigo-500"
-                placeholder="Escribe tu mensaje"
-              />
-            </div>
-            <button
-              type="submit"
-              className="w-full bg-indigo-700 text-white font-semibold py-3 rounded-lg hover:bg-indigo-800 transition"
+          <div className="flex flex-col items-center space-y-4">
+            <a
+              href="https://wa.me/34612356789"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="w-full bg-indigo-700 text-white font-semibold py-3 rounded-lg text-center hover:bg-indigo-800 transition"
             >
-              Enviar Mensaje
-            </button>
-          </form>
+              WhatsApp
+            </a>
+            <a
+              href="https://instagram.com/jotalopedj"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="w-full bg-indigo-700 text-white font-semibold py-3 rounded-lg text-center hover:bg-indigo-800 transition"
+            >
+              Instagram
+            </a>
+            <a
+              href="mailto:jotalopedj@gmail.com"
+              className="w-full bg-indigo-700 text-white font-semibold py-3 rounded-lg text-center hover:bg-indigo-800 transition"
+            >
+              Email
+            </a>
+          </div>
         </section>
   
         {/* Footer */}

--- a/src/components/Contact.css
+++ b/src/components/Contact.css
@@ -14,18 +14,6 @@
   color: white;
 }
 
-.contact-wrapper {
-  display: flex;
-  flex-direction: column;
-  gap: 2rem;
-}
-
-@media (min-width: 768px) {
-  .contact-wrapper {
-    flex-direction: row;
-  }
-}
-
 .contact-info {
   width: 100%;
   font-size: 1.125rem;
@@ -35,34 +23,11 @@
   gap: 0.75rem;
 }
 
-.contact-form {
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.contact-input,
-.contact-textarea {
-  padding: 0.75rem;
-  background-color: #374151;
-  border: 1px solid #4b5563;
-  border-radius: 0.375rem;
+.contact-info a {
   color: white;
-  font-size: 1rem;
+  text-decoration: underline;
 }
 
-.contact-submit {
-  background-color: #7c3aed;
-  color: white;
-  font-weight: bold;
-  padding: 0.75rem;
-  border-radius: 0.375rem;
-  border: none;
-  cursor: pointer;
-  transition: background-color 0.3s ease;
-}
-
-.contact-submit:hover {
-  background-color: #6d28d9;
+.contact-info a:hover {
+  color: #d1d5db;
 }

--- a/src/components/Contact.js
+++ b/src/components/Contact.js
@@ -4,48 +4,28 @@ import { useTranslation } from "react-i18next";
 
 export default function Contact() {
   const { t } = useTranslation();
-  const contactoInfo = t("contactoInfo", { returnObjects: true }) || {};
 
   return (
     <section id="contacto" className="contact-section">
       <div className="display-center">
         <h2 className="contact-title text-gold">{t("nav.contacto")}</h2>
       </div>
-      <div className="contact-wrapper">
-        <div className="contact-info">
-          <p>612356789</p>
-          <p>jotalopedj@gmail.com</p>
-          <p>Malaga</p>
-        </div>
-        <form
-          className="contact-form"
-          onSubmit={(e) => {
-            e.preventDefault();
-            alert("Formulario enviado!");
-          }}
+      <div className="contact-info">
+        <a
+          href="https://wa.me/34612356789"
+          target="_blank"
+          rel="noopener noreferrer"
         >
-          <input
-            type="text"
-            placeholder={contactoInfo.nombrePlaceholder}
-            required
-            className="contact-input"
-          />
-          <input
-            type="email"
-            placeholder={contactoInfo.emailPlaceholder}
-            required
-            className="contact-input"
-          />
-          <textarea
-            placeholder={contactoInfo.mensajePlaceholder}
-            required
-            rows={4}
-            className="contact-textarea"
-          />
-          <button type="submit" className="contact-submit">
-            {contactoInfo.enviarMensaje}
-          </button>
-        </form>
+          WhatsApp
+        </a>
+        <a
+          href="https://instagram.com/jotalopedj"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Instagram
+        </a>
+        <a href="mailto:jotalopedj@gmail.com">jotalopedj@gmail.com</a>
       </div>
     </section>
   );

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -72,12 +72,6 @@
       "precio": "From €1,200"
     }
   ],
-  "contactoInfo": {
-    "nombrePlaceholder": "Your name",
-    "emailPlaceholder": "Your email",
-    "mensajePlaceholder": "Write your message...",
-    "enviarMensaje": "Send Message"
-  },
   "reseñas": [
     {
       "nombre": "Michael R.",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -67,12 +67,6 @@
       "precio": "Desde 1.200€"
     }
   ],
-  "contactoInfo": {
-    "nombrePlaceholder": "Tu nombre",
-    "emailPlaceholder": "Tu correo electrónico",
-    "mensajePlaceholder": "Escribe tu mensaje...",
-    "enviarMensaje": "Enviar Mensaje"
-  },
   "reseñas": [
     {
       "nombre": "Carlos M.",

--- a/src/locales/nl/common.json
+++ b/src/locales/nl/common.json
@@ -72,12 +72,6 @@
       "precio": "Vanaf €1.200"
     }
   ],
-  "contactoInfo": {
-    "nombrePlaceholder": "Jouw naam",
-    "emailPlaceholder": "Jouw e-mail",
-    "mensajePlaceholder": "Typ je bericht...",
-    "enviarMensaje": "Verstuur Bericht"
-  },
   "reseñas": [
     {
       "nombre": "Sofie D.",


### PR DESCRIPTION
## Summary
- remove contact form component and show WhatsApp, Instagram and email links
- drop unused contact form translations across locales
- simplify contact styles for link-based layout

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892915ae4788323a97894d50616e530