### PR TITLE
Add modal with extra info for pricing plans

### DIFF
--- a/src/components/PackageModal.js
+++ b/src/components/PackageModal.js
@@ -1,0 +1,37 @@
+"use client";
+
+import "./ServiceModal.css";
+import "./Services.css"; // for package list styles
+
+export default function PackageModal({ paquete, onClose }) {
+  if (!paquete) return null;
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+        <button className="modal-close" onClick={onClose}>
+          ×
+        </button>
+
+        {paquete.imagen && (
+          <div className="modal-image">
+            <img src={paquete.imagen} alt={paquete.nombre} />
+          </div>
+        )}
+
+        <div className="modal-body">
+          <h2 className="modal-title">{paquete.nombre}</h2>
+          {paquete.descripcion && (
+            <p className="modal-description">{paquete.descripcion}</p>
+          )}
+          <ul className="package-items">
+            {paquete.detalles.map((detalle, i) => (
+              <li key={i}>{detalle}</li>
+            ))}
+          </ul>
+          <p className="package-price text-gold">{paquete.precio}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Prices.js
+++ b/src/components/Prices.js
@@ -1,9 +1,10 @@
 "use client";
 
 import { useTranslation } from "react-i18next";
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { motion, useInView } from "framer-motion";
 import "./Services.css"; // usa mismos estilos
+import PackageModal from "./PackageModal";
 
 export default function Prices() {
   const { t } = useTranslation();
@@ -12,6 +13,7 @@ export default function Prices() {
 
   const ref = useRef(null);
   const isInView = useInView(ref, { once: true, threshold: 0.3 });
+  const [selectedPackage, setSelectedPackage] = useState(null);
 
   return (
     <section id="precios" className="service-packages" ref={ref}>
@@ -40,6 +42,7 @@ export default function Prices() {
               scale: 1.03,
               boxShadow: "0 0 24px rgba(255, 255, 255, 0.15)",
             }}
+            onClick={() => setSelectedPackage(paquete)}
           >
             <h4 className="package-name">{paquete.nombre}</h4>
             <ul className="package-items">
@@ -51,6 +54,10 @@ export default function Prices() {
           </motion.div>
         ))}
       </div>
+      <PackageModal
+        paquete={selectedPackage}
+        onClose={() => setSelectedPackage(null)}
+      />
     </section>
   );
 }

--- a/src/components/Services.css
+++ b/src/components/Services.css
@@ -111,6 +111,7 @@
   transition: transform 0.3s ease, box-shadow 0.3s ease;
   position: relative;
   overflow: hidden;
+  cursor: pointer;
 }
 
 /* 👇 animación tipo reflejo solar */

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -49,7 +49,9 @@
         "Ambient lighting",
         "Pre-event consultation"
       ],
-      "precio": "From €450"
+      "precio": "From €450",
+      "descripcion": "Ideal for intimate gatherings and smaller events. Includes a personalized playlist and fast setup to keep the music flowing.",
+      "imagen": "/images/imagen1.jpg"
     },
     {
       "nombre": "Premium Package",
@@ -59,7 +61,9 @@
         "Full professional lighting",
         "2 planning consultations"
       ],
-      "precio": "From €750"
+      "precio": "From €750",
+      "descripcion": "Perfect for medium-sized celebrations. Features a lit DJ booth, wireless microphone and complete support throughout the event.",
+      "imagen": "/images/imagen2.jpg"
     },
     {
       "nombre": "Exclusive Package",
@@ -69,7 +73,9 @@
         "Special effects and smoke machine",
         "Full event planning support"
       ],
-      "precio": "From €1,200"
+      "precio": "From €1,200",
+      "descripcion": "Our most complete experience for large events. Stage setup, live DJ performance and special effects tailored to your night.",
+      "imagen": "/images/imagen3.avif"
     }
   ],
   "reseñas": [

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -44,7 +44,9 @@
         "Iluminación ambiental",
         "Consulta previa al evento"
       ],
-      "precio": "Desde 450€"
+      "precio": "Desde 450€",
+      "descripcion": "Ideal para eventos íntimos y reuniones pequeñas. Incluye playlist personalizada y montaje rápido para que todo suene perfecto desde el inicio.",
+      "imagen": "/images/imagen1.jpg"
     },
     {
       "nombre": "Paquete Premium",
@@ -54,7 +56,9 @@
         "Iluminación profesional completa",
         "2 consultas de planificación"
       ],
-      "precio": "Desde 750€"
+      "precio": "Desde 750€",
+      "descripcion": "Pensado para celebraciones medianas. Cabina iluminada, micrófono inalámbrico y asistencia completa durante tu evento.",
+      "imagen": "/images/imagen2.jpg"
     },
     {
       "nombre": "Paquete Exclusivo",
@@ -64,7 +68,9 @@
         "Efectos especiales y máquina de humo",
         "Planificación completa del evento"
       ],
-      "precio": "Desde 1.200€"
+      "precio": "Desde 1.200€",
+      "descripcion": "Nuestra opción más completa para grandes eventos. Escenario, DJ en vivo, efectos especiales y atención personalizada de principio a fin.",
+      "imagen": "/images/imagen3.avif"
     }
   ],
   "reseñas": [

--- a/src/locales/nl/common.json
+++ b/src/locales/nl/common.json
@@ -49,7 +49,9 @@
         "Sfeerverlichting",
         "Voorafgaand consult"
       ],
-      "precio": "Vanaf €450"
+      "precio": "Vanaf €450",
+      "descripcion": "Ideaal voor intieme bijeenkomsten en kleine events. Inclusief gepersonaliseerde afspeellijst en snelle opbouw zodat de muziek meteen start.",
+      "imagen": "/images/imagen1.jpg"
     },
     {
       "nombre": "Premium Pakket",
@@ -59,7 +61,9 @@
         "Volledige professionele verlichting",
         "2 planningsgesprekken"
       ],
-      "precio": "Vanaf €750"
+      "precio": "Vanaf €750",
+      "descripcion": "Perfect voor middelgrote feesten. Voorzien van verlichte DJ-booth, draadloze microfoon en volledige ondersteuning tijdens het event.",
+      "imagen": "/images/imagen2.jpg"
     },
     {
       "nombre": "Exclusief Pakket",
@@ -69,7 +73,9 @@
         "Speciale effecten en rookmachine",
         "Volledige eventplanning"
       ],
-      "precio": "Vanaf €1.200"
+      "precio": "Vanaf €1.200",
+      "descripcion": "Onze meest complete ervaring voor grote evenementen. Inclusief podium, live DJ en special effects op maat van jouw avond.",
+      "imagen": "/images/imagen3.avif"
     }
   ],
   "reseñas": [


### PR DESCRIPTION
## Summary
- add modal for pricing cards with extra details and images
- extend translations with description and image fields
- style package cards as clickable

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fdf3f04e08323bb3c9deda9afde00